### PR TITLE
Updated Functionality with additional buttons to simplify usage + rearrangement of pre-edit metadata

### DIFF
--- a/PackageExplorer/AboutWindow.xaml
+++ b/PackageExplorer/AboutWindow.xaml
@@ -1,6 +1,6 @@
-﻿<self:StandardDialog x:Class="PackageExplorer.AboutWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:self="clr-namespace:PackageExplorer" xmlns:settings="clr-namespace:PackageExplorer.Properties" xmlns:resources="clr-namespace:PackageExplorer.Resources" FontSize="{Binding FontSize, Source={x:Static settings:Settings.Default}}" Title="{x:Static resources:Resources.Dialog_Title}" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" SizeToContent="WidthAndHeight" ShowInTaskbar="False">
+﻿<self:StandardDialog x:Class="PackageExplorer.AboutWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:self="clr-namespace:PackageExplorer" xmlns:settings="clr-namespace:PackageExplorer.Properties" xmlns:resources="clr-namespace:PackageExplorer.Resources" FontSize="{Binding FontSize, Source={x:Static settings:Settings.Default}}" Title="{x:Static resources:Resources.Dialog_Title}" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" SizeToContent="WidthAndHeight" ShowInTaskbar="False" Height="263">
 
-    <DockPanel LastChildFill="true">
+    <DockPanel LastChildFill="true" Margin="0,0,0,-6">
 
         <Border DockPanel.Dock="Bottom" Margin="0,30,0,0" BorderThickness="0,0.5,0,0" BorderBrush="{DynamicResource ResourceKey={x:Static SystemColors.ActiveBorderBrushKey}}" Background="{DynamicResource ResourceKey={x:Static SystemColors.ControlBrushKey}}">
             <Button Content="OK" Padding="20,0,20,0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="10,10,15,10" IsDefault="True" IsCancel="True" Click="Button_Click" />
@@ -8,10 +8,10 @@
 
         <Image Style="{x:Null}" Margin="15,20,0,0" DockPanel.Dock="Left" Stretch="None" VerticalAlignment="Top" Source="Images/packageicon.png" />
 
-        <StackPanel Orientation="Vertical" Grid.Column="1" Margin="15,20,15,0">
+        <StackPanel Orientation="Vertical" Grid.Column="1" Margin="15,20,15,-10" Width="355">
             <TextBlock x:Name="ProductTitle" Text="NuGet Package Explorer" FontWeight="Bold" />
 
-        
+
             <TextBlock Margin="0,5,0,0">
 				<Hyperlink NavigateUri="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer" Click="Hyperlink_Click">
 					<Run Text="https://github.com/NuGetPackageExplorer/NuGetPackageExplorer" />
@@ -31,6 +31,9 @@
             </TextBlock>
             <TextBlock Margin="0,5,0,0">
 				<Run Text="Some dates are formatted by " /><Hyperlink NavigateUri="https://github.com/Humanizr/Humanizer" Click="Hyperlink_Click"><Run Text="Humanizer" /></Hyperlink><Run Text="." />
+            </TextBlock>
+            <TextBlock Margin="0,5,0,0">
+                <Run Text="Customized solution provided by " /><Hyperlink NavigateUri="https://github.com/ItsMrQ/NugetPE-Mod-v3.23" Click="Hyperlink_Click"><Run Text="ItsMrQ" /></Hyperlink><Run Text="." />
             </TextBlock>
         </StackPanel>
     </DockPanel>

--- a/PackageExplorer/PackageMetadataEditor.xaml
+++ b/PackageExplorer/PackageMetadataEditor.xaml
@@ -110,10 +110,23 @@
                     </Binding>
                 </TextBox.Text>
             </TextBox>
-        <!---Decrease Version-->
+            <!--Renew Version (New Month)-->
             <Button Grid.Row="1" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="20,0,0,0"
+                            Margin="8,0,0,0"
+                            Width = "20"
+                            ToolTipService.ToolTip="Renew Version"
+                            Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
+                            Command="{Binding RenewVersionCommand}">
+
+                <Grid>
+                    <Image Source="Images/Props.png" />
+                </Grid>
+            </Button>
+            <!---Decrease Version-->
+            <Button Grid.Row="1" Grid.Column="0"
+                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
+                            Margin="45,0,0,0"
                             Width = "20"
                             ToolTipService.ToolTip="Decrease Version"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
@@ -126,7 +139,7 @@
             <!--Increase Version-->
             <Button Grid.Row="1" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="60,0,0,0"
+                            Margin="80,0,0,0"
                             Width = "20"
                             ToolTipService.ToolTip="Increase Version"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"

--- a/PackageExplorer/PackageMetadataEditor.xaml
+++ b/PackageExplorer/PackageMetadataEditor.xaml
@@ -98,10 +98,7 @@
 
             <!-- Version -->
             <Label Grid.Row="1" Grid.Column="0" Target="VersionBox" Style="{StaticResource RequiredLabelStyle}" Content="_Version" />
-
-
             <TextBox Grid.Row="1" Grid.Column="1" x:Name="VersionBox">
-
                 <TextBox.Text>
                     <Binding Path="PackageMetadata.Version" Converter="{StaticResource VersionConverter}" ValidatesOnDataErrors="True">
                         <Binding.ValidationRules>
@@ -155,6 +152,18 @@
 
             <!-- Authors -->
             <Label Grid.Row="3" Grid.Column="0" Target="AuthorsBox" Style="{StaticResource RequiredLabelStyle}" Content="_Authors" />
+            <!--Update Author-->
+            <Button Grid.Row="3" Grid.Column="0"
+                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
+                            Margin="82,5,2,3"
+                            Width = "20"
+                            ToolTipService.ToolTip="Update Author"
+                            Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
+                            Command="{Binding UpdateAuthorsCommand}">
+                <Grid>
+                    <Image Source="Images/props.png" />
+                </Grid>
+            </Button>
             <TextBox Grid.Row="3" Grid.Column="1" x:Name="AuthorsBox" Text="{Binding PackageMetadata.Authors, ValidatesOnDataErrors=True}" />
 
             <!-- Owners -->

--- a/PackageExplorer/PackageMetadataEditor.xaml
+++ b/PackageExplorer/PackageMetadataEditor.xaml
@@ -110,7 +110,7 @@
             <!--Renew Version (New Month)-->
             <Button Grid.Row="1" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="8,0,0,0"
+                            Margin="47,5,39,3"
                             Width = "20"
                             ToolTipService.ToolTip="Renew Version"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
@@ -123,7 +123,7 @@
             <!---Decrease Version-->
             <Button Grid.Row="1" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="45,0,0,0"
+                            Margin="64,5,19,3"
                             Width = "20"
                             ToolTipService.ToolTip="Decrease Version"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
@@ -136,7 +136,7 @@
             <!--Increase Version-->
             <Button Grid.Row="1" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="80,0,0,0"
+                            Margin="82,5,0,3"
                             Width = "20"
                             ToolTipService.ToolTip="Increase Version"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
@@ -155,7 +155,7 @@
             <!--Update Author-->
             <Button Grid.Row="3" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="82,5,2,3"
+                            Margin="84,5,2,3"
                             Width = "20"
                             ToolTipService.ToolTip="Update Author"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
@@ -206,7 +206,7 @@
                 <!--Reset Description-->
                 <Button Grid.Row="11" Grid.Column="0"
                             Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
-                            Margin="8,0,0,55"
+                            Margin="10,0,0,55"
                             Width = "20"
                             ToolTipService.ToolTip="Clear Description, Release Notes and Summary"
                             Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"

--- a/PackageExplorer/PackageMetadataEditor.xaml
+++ b/PackageExplorer/PackageMetadataEditor.xaml
@@ -120,7 +120,7 @@
                             Command="{Binding RenewVersionCommand}">
 
                 <Grid>
-                    <Image Source="Images/Props.png" />
+                    <Image Source="Images/Tools.png" />
                 </Grid>
             </Button>
             <!---Decrease Version-->
@@ -192,9 +192,23 @@
             <TextBox Grid.Row="10" Grid.Column="1" x:Name="LicenseUrlBox" Text="{Binding PackageMetadata.LicenseUrl, Converter={StaticResource UriConverter}, ValidatesOnDataErrors=true}" />
 
             <!-- Description -->
+            <StackPanel Orientation="Horizontal" Grid.Row="11" Grid.Column="0">
             <Label Grid.Row="11" Grid.Column="0" Target="DescriptionBox" Style="{StaticResource RequiredLabelStyle}" Content="_Description" />
+                <!--Reset Description-->
+                <Button Grid.Row="11" Grid.Column="0"
+                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" 
+                            Margin="8,0,0,55"
+                            Width = "20"
+                            ToolTipService.ToolTip="Clear Description, Release Notes and Summary"
+                            Visibility="{Binding IsInEditMetadataMode, Converter={StaticResource boolToVis}}"
+                            Command="{Binding ResetMetadataFieldsCommand}">
+                    <Grid>
+                        <Image Source="Images/Properties.png" />
+                    </Grid>
+                </Button>
+            </StackPanel>
             <TextBox Grid.Row="11" Grid.Column="1" Height="80" MaxLength="2000" VerticalContentAlignment="Top" VerticalScrollBarVisibility="Auto" TextWrapping="Wrap" x:Name="DescriptionBox" Text="{Binding PackageMetadata.Description, ValidatesOnDataErrors=True}" AcceptsReturn="True" />
-
+                       
             <!-- Release Notes -->
             <Label Grid.Row="12" Grid.Column="0" Target="ReleaseNotesBox" Style="{StaticResource LabelStyle}" Content="_Release Notes" />
             <TextBox Grid.Row="12" Grid.Column="1" Height="50" VerticalContentAlignment="Top" VerticalScrollBarVisibility="Auto" TextWrapping="Wrap" x:Name="ReleaseNotesBox" Text="{Binding PackageMetadata.ReleaseNotes}" AcceptsReturn="True" />

--- a/PackageExplorer/PackageViewer.xaml
+++ b/PackageExplorer/PackageViewer.xaml
@@ -258,11 +258,6 @@
                             <TextBlock Text="{Binding Serviceable, Converter={StaticResource BooleanConverter}}" Style="{StaticResource DetailMetadataValueStyle}" />
                         </StackPanel>
 
-                        <!-- Summary -->
-                        <TextBlock Text="Summary:" Margin="0,3,0,0" Style="{StaticResource DetailMetadataLabelStyle}" Visibility="{Binding Summary, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
-
-                        <TextBlock Style="{StaticResource DetailDescriptionTextBoxStyle}" Text="{Binding Summary, Converter={StaticResource NormalizeTextConverter}}" Visibility="{Binding Summary, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
-
                         <!-- Description -->
                         <TextBlock Text="Description:" Margin="0,3,0,0" Style="{StaticResource DetailMetadataLabelStyle}"></TextBlock>
 
@@ -272,6 +267,11 @@
                         <TextBlock Text="Release notes:" Margin="0,3,0,0" Style="{StaticResource DetailMetadataLabelStyle}" Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
 
                         <TextBlock Style="{StaticResource DetailDescriptionTextBoxStyle}" Text="{Binding ReleaseNotes, Converter={StaticResource NormalizeTextConverter}}" Visibility="{Binding ReleaseNotes, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
+                        
+                        <!-- Summary -->
+                        <TextBlock Text="Summary:" Margin="0,3,0,0" Style="{StaticResource DetailMetadataLabelStyle}" Visibility="{Binding Summary, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
+
+                        <TextBlock Style="{StaticResource DetailDescriptionTextBoxStyle}" Text="{Binding Summary, Converter={StaticResource NormalizeTextConverter}}" Visibility="{Binding Summary, Converter={StaticResource NullToVisibilityConverter}}"></TextBlock>
 
                         <!-- Dependencies list -->
                         <TextBlock Text="{x:Static resources:Resources.Dialog_DependenciesLabel}" Style="{StaticResource DetailMetadataLabelStyle}" />

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -44,14 +44,15 @@ namespace PackageExplorerViewModel
             get { return _authors; }
             set
             {
-                if (String.IsNullOrWhiteSpace(value))
+               /* if (String.IsNullOrWhiteSpace(value))
                 {
                     const string message = "Authors is required.";
                     SetError("Authors", message);
                     throw new ArgumentException(message);
                 }
 
-                SetError("Authors", null);
+                SetError("Authors", null); 
+                */
                 if (_authors != value)
                 {
                     _authors = value;
@@ -183,6 +184,7 @@ namespace PackageExplorerViewModel
         public string RevertDescription { get; set; }
         public string RevertReleaseNotes { get; set; }
         public string RevertSummary { get; set; }
+        public string RevertAuthors { get; set; }
         public string Title
         {
             get { return _title; }

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -26,7 +26,6 @@ namespace PackageExplorerViewModel
         private bool _serviceable;
         private string _title;
         private TemplatebleSemanticVersion _version;
-        private TemplatebleSemanticVersion _revertVersion;
         private ICollection<PackageDependencySet> _dependencySets;
         private ICollection<PackageReferenceSet> _packageAssemblyReferences;
         private Version _minClientVersion;
@@ -180,11 +179,10 @@ namespace PackageExplorerViewModel
                 }
             }
         }
-        public TemplatebleSemanticVersion RevertVersion
-        {
-            get { return _revertVersion;}
-            set { _revertVersion = value;}
-        }
+        public TemplatebleSemanticVersion RevertVersion { get; set; }
+        public string RevertDescription { get; set; }
+        public string RevertReleaseNotes { get; set; }
+        public string RevertSummary { get; set; }
         public string Title
         {
             get { return _title; }

--- a/PackageViewModel/EditablePackageMetadata.cs
+++ b/PackageViewModel/EditablePackageMetadata.cs
@@ -44,7 +44,7 @@ namespace PackageExplorerViewModel
             get { return _authors; }
             set
             {
-               /* if (String.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value))
                 {
                     const string message = "Authors is required.";
                     SetError("Authors", message);
@@ -52,7 +52,7 @@ namespace PackageExplorerViewModel
                 }
 
                 SetError("Authors", null); 
-                */
+                
                 if (_authors != value)
                 {
                     _authors = value;

--- a/PackageViewModel/EmptyPackage.cs
+++ b/PackageViewModel/EmptyPackage.cs
@@ -32,7 +32,8 @@ namespace PackageExplorerViewModel
 
         public TemplatebleSemanticVersion Version
         {
-            get{
+            get
+            {
                 int year = (DateTime.Now.Year) % 100;
                 string month = (DateTime.Now.Month).ToString().PadLeft(2, '0'); /*Keep leading zero*/
                 return TemplatebleSemanticVersion.Parse(year + "." + month + "." + "001"); /*YYYY.MM.001 automatic monthly versioning*/

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -1326,7 +1326,7 @@ namespace PackageExplorerViewModel
         }
         private void UpdateAuthors()
         {
-            PackageMetadata.Authors = string.Empty;
+            PackageMetadata.Authors = "*";
             PackageMetadata.Authors = Environment.UserName;
         }
         internal void OnSaved(string fileName)

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -36,6 +36,7 @@ namespace PackageExplorerViewModel
         private ICommand _addBuildFileCommand;
         private ICommand _applyEditCommand;
         private ICommand _cancelEditCommand;
+        private ICommand _renewVersionCommand;
         private ICommand _incrementVersionCommand;
         private ICommand _decrementVersionCommand;
         private FileContentInfo _currentFileInfo;
@@ -500,7 +501,19 @@ namespace PackageExplorerViewModel
 
         #endregion
 
-
+        #region RenewVersionCommand
+        public ICommand RenewVersionCommand
+        {
+            get
+            {
+                if (_renewVersionCommand == null)
+                {
+                    _renewVersionCommand = new RelayCommand(RenewVersion, () => !IsInEditFileMode);
+                }
+                return _renewVersionCommand;
+            }
+        }
+        #endregion
 
         #region IncreaseVersionCommand
         public ICommand IncreaseVersionCommand
@@ -1211,7 +1224,13 @@ namespace PackageExplorerViewModel
             IsInEditMetadataMode = false;
         }
 
-        #region IncreaseVersion/DecreaseVersion/UpdateVersion/PaddedValue
+        #region RenewVersion/IncreaseVersion/DecreaseVersion/UpdateVersion/PaddedValue
+        private void RenewVersion()
+        {
+            int year = (DateTime.Now.Year) % 100;
+            string month = (DateTime.Now.Month).ToString().PadLeft(2, '0'); 
+            PackageMetadata.Version = TemplatebleSemanticVersion.Parse(year + "." + month + "." + "001"); 
+        }
         private void IncreaseVersion()
         {
             UpdateVersion(true); /*Increment value*/

--- a/PackageViewModel/PackageViewModel.cs
+++ b/PackageViewModel/PackageViewModel.cs
@@ -36,6 +36,7 @@ namespace PackageExplorerViewModel
         private ICommand _addBuildFileCommand;
         private ICommand _applyEditCommand;
         private ICommand _cancelEditCommand;
+        private ICommand _updateAuthorsCommand;
         private ICommand _renewVersionCommand;
         private ICommand _resetMetadataFieldsCommand;
         private ICommand _incrementVersionCommand;
@@ -524,6 +525,19 @@ namespace PackageExplorerViewModel
                     _renewVersionCommand = new RelayCommand(RenewVersion, () => !IsInEditFileMode);
                 }
                 return _renewVersionCommand;
+            }
+        }
+        #endregion
+        #region UpdateAuthorsCommand
+        public ICommand UpdateAuthorsCommand
+        {
+            get
+            {
+                if (_updateAuthorsCommand == null)
+                {
+                    _updateAuthorsCommand = new RelayCommand(UpdateAuthors, () => !IsInEditFileMode);
+                }
+                return _updateAuthorsCommand;
             }
         }
         #endregion
@@ -1241,6 +1255,7 @@ namespace PackageExplorerViewModel
             PackageMetadata.RevertDescription = PackageMetadata.Description;
             PackageMetadata.RevertReleaseNotes = PackageMetadata.ReleaseNotes;
             PackageMetadata.RevertSummary = PackageMetadata.Summary;
+            PackageMetadata.RevertAuthors = PackageMetadata.Authors;
         }
         private void RestoreMetaDataFields()
         {
@@ -1248,12 +1263,18 @@ namespace PackageExplorerViewModel
             PackageMetadata.Description = PackageMetadata.RevertDescription;
             PackageMetadata.ReleaseNotes = PackageMetadata.RevertReleaseNotes;
             PackageMetadata.Summary = PackageMetadata.RevertSummary;
+            PackageMetadata.Authors = PackageMetadata.RevertAuthors;
         }
         private void ResetMetadataFields()
         {
+            /*Double assignment garbage collection bypass*/
+            PackageMetadata.Description = "*";
+            PackageMetadata.ReleaseNotes = "*";
+            PackageMetadata.Summary = "*";
+
             PackageMetadata.Description = "My package description.";
-            PackageMetadata.ReleaseNotes = "";
-            PackageMetadata.Summary = "";
+            PackageMetadata.ReleaseNotes = string.Empty;
+            PackageMetadata.Summary = string.Empty;
         }
         #region RenewVersion/IncreaseVersion/DecreaseVersion/UpdateVersion/PaddedValue
         private void RenewVersion()
@@ -1299,13 +1320,15 @@ namespace PackageExplorerViewModel
         private void CommitEdit()
         {
             HasEdit = true;
-           // PackageMetadata.Authors = IPackageMetadata.Authors;//NuGetPe.Authors.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-            //   PackageMetadata.Authors = ConvertToString(source.Authors);
             PackageMetadata.ResetErrors();
             IsInEditMetadataMode = false;
             OnPropertyChanged("WindowTitle");
         }
-
+        private void UpdateAuthors()
+        {
+            PackageMetadata.Authors = string.Empty;
+            PackageMetadata.Authors = Environment.UserName;
+        }
         internal void OnSaved(string fileName)
         {
             HasEdit = false;


### PR DESCRIPTION
New buttons added to renew monthly versioning, update the current author modifying a package, reset actively used fields such as Description, Release Notes and Summary and a link to this GitHub. 